### PR TITLE
Fixed variable scope problem for Puppet 4.

### DIFF
--- a/templates/email_alert_recipients.erb
+++ b/templates/email_alert_recipients.erb
@@ -1,4 +1,4 @@
-<% @email_recipients.keys.sort.each do |recipient| -%>
-<% filter_type = @email_recipients[recipient]['filter_type'] || 'after_first' -%>
+<% scope.lookupvar('setroubleshoot::email_recipients').keys.sort.each do |recipient| -%>
+<% filter_type = scope.lookupvar('setroubleshoot::email_recipients')[recipient]['filter_type'] || 'after_first' -%>
 <%= recipient %> filter_type=<%= filter_type %>
 <% end -%>


### PR DESCRIPTION
The module failed on Puppet 4 server because the template thought that  @email_recipients variable was nil.  